### PR TITLE
feat: Add EthereumGatewayAddress to parameters pallet

### DIFF
--- a/chains/orchestrator-relays/runtime/dancelight/src/bridge_to_ethereum_config.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/bridge_to_ethereum_config.rs
@@ -49,7 +49,7 @@ use {
     snowbridge_router_primitives::inbound::{
         envelope::Envelope, Command, Destination, MessageProcessor, MessageV1, VersionedXcmMessage,
     },
-    sp_core::{ConstU32, ConstU8, Get, H160, H256},
+    sp_core::{ConstU32, ConstU8, Get, H256},
     sp_runtime::{traits::Zero, DispatchError, DispatchResult},
     sp_std::{marker::PhantomData, vec},
     tp_bridge::{DoNothingConvertMessage, DoNothingRouter, EthereumSystemHandler},
@@ -61,9 +61,7 @@ use {
 };
 
 // Ethereum Bridge
-parameter_types! {
-    pub storage EthereumGatewayAddress: H160 = H160(hex_literal::hex!("EDa338E4dC46038493b885327842fD3E301CaB39"));
-}
+// EthereumGatewayAddress is now defined in dynamic_params::bridge
 
 parameter_types! {
     pub Parameters: PricingParameters<u128> = PricingParameters {
@@ -525,7 +523,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
     type Token = Balances;
     // TODO: Revisit this when we enable xcmp messages
     type XcmSender = DoNothingRouter;
-    type GatewayAddress = EthereumGatewayAddress;
+    type GatewayAddress = crate::dynamic_params::bridge::EthereumGatewayAddress;
     // TODO: Revisit this when we enable xcmp messages
     type MessageConverter = DoNothingConvertMessage;
     type ChannelLookup = EthereumSystem;

--- a/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/dancelight/src/lib.rs
@@ -387,6 +387,15 @@ pub mod dynamic_params {
         #[codec(index = 1)]
         pub static ByteDeposit: Balance = deposit(0, 1);
     }
+
+    #[dynamic_pallet_params]
+    #[codec(index = 1)]
+    pub mod bridge {
+        use super::*;
+
+        #[codec(index = 0)]
+        pub static EthereumGatewayAddress: sp_core::H160 = sp_core::H160(hex_literal::hex!("EDa338E4dC46038493b885327842fD3E301CaB39"));
+    }
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -412,6 +421,7 @@ impl EnsureOriginWithArg<RuntimeOrigin, RuntimeParametersKey> for DynamicParamet
 
         match key {
             Preimage(_) => frame_system::ensure_root(origin.clone()),
+            Bridge(_) => frame_system::ensure_root(origin.clone()),
         }
         .map_err(|_| origin)
     }

--- a/chains/orchestrator-relays/runtime/starlight/src/bridge_to_ethereum_config.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/bridge_to_ethereum_config.rs
@@ -48,15 +48,13 @@ use {
     snowbridge_router_primitives::inbound::{
         envelope::Envelope, Command, Destination, MessageProcessor, MessageV1, VersionedXcmMessage,
     },
-    sp_core::{ConstU32, ConstU8, Get, H160, H256},
+    sp_core::{ConstU32, ConstU8, Get, H256},
     sp_runtime::{traits::Zero, DispatchError, DispatchResult},
     tp_bridge::{DoNothingConvertMessage, DoNothingRouter, EthereumSystemHandler},
 };
 
 // Ethereum Bridge
-parameter_types! {
-    pub storage EthereumGatewayAddress: H160 = H160(hex_literal::hex!("EDa338E4dC46038493b885327842fD3E301CaB39"));
-}
+// EthereumGatewayAddress is now defined in dynamic_params::bridge
 
 parameter_types! {
     pub Parameters: PricingParameters<u128> = PricingParameters {
@@ -331,7 +329,7 @@ impl snowbridge_pallet_inbound_queue::Config for Runtime {
     type Token = Balances;
     // TODO: Revisit this when we enable xcmp messages
     type XcmSender = DoNothingRouter;
-    type GatewayAddress = EthereumGatewayAddress;
+    type GatewayAddress = crate::dynamic_params::bridge::EthereumGatewayAddress;
     // TODO: Revisit this when we enable xcmp messages
     type MessageConverter = DoNothingConvertMessage;
     type ChannelLookup = EthereumSystem;

--- a/chains/orchestrator-relays/runtime/starlight/src/lib.rs
+++ b/chains/orchestrator-relays/runtime/starlight/src/lib.rs
@@ -409,6 +409,15 @@ pub mod dynamic_params {
         #[codec(index = 1)]
         pub static ByteDeposit: Balance = deposit(0, 1);
     }
+
+    #[dynamic_pallet_params]
+    #[codec(index = 1)]
+    pub mod bridge {
+        use super::*;
+
+        #[codec(index = 0)]
+        pub static EthereumGatewayAddress: sp_core::H160 = sp_core::H160(hex_literal::hex!("EDa338E4dC46038493b885327842fD3E301CaB39"));
+    }
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -434,6 +443,7 @@ impl EnsureOriginWithArg<RuntimeOrigin, RuntimeParametersKey> for DynamicParamet
 
         match key {
             Preimage(_) => frame_system::ensure_root(origin.clone()),
+            Bridge(_) => frame_system::ensure_root(origin.clone()),
         }
         .map_err(|_| origin)
     }


### PR DESCRIPTION
Moved EthereumGatewayAddress from a storage parameter to the dynamic parameters pallet, making it easier to modify via governance without needing to know the storage key.

Changes:
- Added bridge module to dynamic_params in both runtimes
- Configured root origin access for bridge parameters
- Updated snowbridge inbound queue config to use dynamic parameter
- Removed redundant H160 imports from bridge configs

This change maintains the same functionality while improving the parameter management experience.